### PR TITLE
Add bower support

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,0 +1,19 @@
+{
+    "name"            : "heap"
+  , "version"         : "0.2.3"
+  , "description"     : "binary heap (priority queue) algorithms (ported from Python's heapq module)"
+  , "homepage"        : "https://github.com/qiao/heap.js"
+  , "keywords"        : ["algorithm", "data structure", "heap"]
+  , "author"          : "Xueqiao Xu <xueqiaoxu@gmail.com>"
+  , "main"            : "./index.js"
+  , "dependencies"    : {}
+  , "devDependencies" : {}
+  , "repository"      : {
+      "type"          : "git"
+    , "url"           : "git://github.com/qiao/heap.js.git"
+  }
+  , "licenses"        : [{
+      "type"          :  "PSF"
+    , "url"           : "http://docs.python.org/license.html"
+  }]
+}


### PR DESCRIPTION
I was trying to test the json and I accidentally added the official repo to the bower registry. On the positive side if the pull request is merged I'd expect bower support to work already. Though, if you decide you don't want to merge let me know and I'll get it unregistered (it's a manual process at the moment).
