### PR TITLE
allow using Heap.js in a webWorker

### DIFF
--- a/lib/heap.js
+++ b/lib/heap.js
@@ -363,7 +363,7 @@
   if (typeof module !== "undefined" && module !== null ? module.exports : void 0) {
     module.exports = Heap;
   } else {
-    window.Heap = Heap;
+    self.Heap = Heap;
   }
 
 }).call(this);


### PR DESCRIPTION
in a worker, the global 'window' object does not exist, whereas the 'self' global object exists in both cases