### PR TITLE
Don't include 'test' in bower install

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -16,4 +16,7 @@
       "type"          :  "PSF"
     , "url"           : "http://docs.python.org/license.html"
   }]
+  , "ignore"          : [
+      "test"
+  ]
 }


### PR DESCRIPTION
Currently when installing the package with bower it complains that you don't have an 'ignore' property:

```
bower heap#~0.2.6         invalid-meta heap is missing "ignore" entry in bower.json
```

Now added this, both to stop the warning, and to actually ignore the tests directory (which currently gets downloaded and included locally whenever you depend on heap.js)